### PR TITLE
Fix/deprecated llama 3 1 70 b

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from models.llama_3_1_70B import llama_3_1_70B
+from models.llama_3_3_70B import llama_3_3_70B
 from tools.reddit_scrapper import reddit_scrapper
 from tools.reddit_commenter import reddit_commenter
 from termcolor import colored
@@ -75,7 +75,7 @@ def chain_of_action(model, system_prompt_sentiment_analyzer, system_prompt_write
 
 if __name__ == "__main__":
 
-    model = llama_3_1_70B()
+    model = llama_3_3_70B()
     system_prompt_sentiment_analyzer, system_prompt_writer = prepare_system_prompts()
     chain_of_action(model, system_prompt_sentiment_analyzer=system_prompt_sentiment_analyzer,
                     system_prompt_writer=system_prompt_writer)

--- a/models/llama_3_3_70B.py
+++ b/models/llama_3_3_70B.py
@@ -4,14 +4,14 @@ from dotenv import dotenv_values
 CONFIG = dotenv_values("config/.env")
 
 
-class llama_3_1_70B:
+class llama_3_3_70B:
 
     def __init__(self):
         """
         Initializes the llama-3.1-70B with the given parameters.
         """
         self.client = Groq(api_key=CONFIG["GROQ_API_KEY"])
-        self.model_name = "llama-3.1-70b-versatile"
+        self.model_name = "llama-3.3-70b-versatile"
 
     def answer(self, system_prompt, prompt, json):
         """


### PR DESCRIPTION
`llama_3_1_70B` shows to be deprecated. Updated to `llama_3_3_70B` per the [doc's](https://console.groq.com/docs/deprecations) recommendation. Addresses #8 .

Copilot summary:
This pull request updates the language model used throughout the application from `llama_3_1_70B` to `llama_3_3_70B`. The changes ensure that the newer model version is instantiated and referenced in all relevant files and code paths.

Model upgrade:

* Renamed `models/llama_3_1_70B.py` to `models/llama_3_3_70B.py` and updated the class name and model identifier from `llama_3_1_70B`/`llama-3.1-70b-versatile` to `llama_3_3_70B`/`llama-3.3-70b-versatile`.
* Updated import statements and model instantiation in `app.py` to use the new `llama_3_3_70B` class. [[1]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L1-R1) [[2]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L78-R78)